### PR TITLE
Misc. improvements to solve and tuning functions for `log_output`

### DIFF
--- a/src/docplex_extensions/_model_funcs.py
+++ b/src/docplex_extensions/_model_funcs.py
@@ -131,9 +131,10 @@ def solve(model: Model, **kwargs: Any) -> SolveSolution | None:
         # Write problem statistics
         if cplex.get_problem_name() != model.name:
             cplex.set_problem_name(model.name)
-        stream.write(f'  {model.problem_type} problem statistics  '.center(div_len, '-') + '\n\n')
-        stream.write(str(cplex.get_stats()))
-        stream.write('\n' + '  CPLEX optimizer log  '.center(div_len, '-') + '\n\n')
+        log_header = f'  {model.problem_type} problem statistics  '.center(div_len, '-') + '\n\n'
+        log_header += str(cplex.get_stats())
+        log_header += '\n' + '  CPLEX optimizer log  '.center(div_len, '-') + '\n\n'
+        stream.write(log_header)
 
     # Don't close the output stream; hand it over to `model.solve`
     solve_setting = stream if to_log else None
@@ -148,9 +149,10 @@ def solve(model: Model, **kwargs: Any) -> SolveSolution | None:
             stream = open(stream._target.name, 'a')
 
         # Write solution quality statistics
-        stream.write('\n' + '  Solution quality statistics  '.center(div_len, '-') + '\n\n')
-        stream.write(str(cplex.solution.get_quality_metrics()))
-        stream.write('\n' + '-' * div_len + '\n')
+        log_footer = '\n' + '  Solution quality statistics  '.center(div_len, '-') + '\n\n'
+        log_footer += str(cplex.solution.get_quality_metrics())
+        log_footer += '\n' + '-' * div_len + '\n'
+        stream.write(log_footer)
 
         # When logging to stream objects, close them at the end
         if to_reopen:

--- a/src/docplex_extensions/_model_funcs.py
+++ b/src/docplex_extensions/_model_funcs.py
@@ -59,9 +59,9 @@ def solve(model: Model, **kwargs: Any) -> SolveSolution | None:
     log_output : bool or str or stream object, optional
         Log output switch, in one of the following forms:
 
-        * ``True`` or ``'stdout'`` or ``'sys.stdout'``: Log is output to stdout.
+        * ``True`` or ``'1'`` or ``'stdout'`` or ``'sys.stdout'``: Log is output to stdout.
         * ``'stderr'`` or ``'sys.stderr'``: Log is output to stderr.
-        * ``False`` or ``None``: No log output.
+        * ``False`` or ``'0'`` or ``None``: No log output.
         * File path (in form of str): Log is output to the file.
         * Stream object (a file-like object with a write method and a flush method): Log is output
           to the stream object.
@@ -116,8 +116,9 @@ def solve(model: Model, **kwargs: Any) -> SolveSolution | None:
         out = model.context.solver.log_output_as_stream
     else:  # nothing otherwise
         out = False
+    to_log = out not in (False, '0', None)
 
-    if out:
+    if to_log:
         div_len = 85
         cplex = model.get_cplex()
 
@@ -135,13 +136,13 @@ def solve(model: Model, **kwargs: Any) -> SolveSolution | None:
         stream.write('\n' + '  CPLEX optimizer log  '.center(div_len, '-') + '\n\n')
 
     # Don't close the output stream; hand it over to `model.solve`
-    solve_setting = stream if out else None
+    solve_setting = stream if to_log else None
     # Remove if stream is in `kwargs` since we're handing it through an explicit argument
     kwargs.pop('log_output', None)
     # Invoke the actual method
     solution = model.solve(log_output=solve_setting, **kwargs)
 
-    if out:
+    if to_log:
         # `model.solve` auto-closes stream objects, so reopen
         if to_reopen:
             stream = open(stream._target.name, 'a')

--- a/src/docplex_extensions/_tuning_funcs.py
+++ b/src/docplex_extensions/_tuning_funcs.py
@@ -231,8 +231,8 @@ def _tune(
         status = cplex.parameters.tune_problem(param_set)
 
     improving_params_and_values = {}
-    # Cannot test since there's no deterministic way to test the tuning tool across multiple CPLEX
-    # versions
+    # Exclude from coverage since there's no clear way to deterministically test the tuning tool
+    # across multiple CPLEX versions. Also, it's not critial as it's only populating a dict.
     for param, param_value in cplex.parameters.get_changed():  # pragma: no cover
         param_name = get_name(param)
         if param_name not in fixed_params_and_values and param_name not in tuning_params:
@@ -252,10 +252,15 @@ def _tune(
 
         stream.write(log_footer)
         stream.flush()
+        try:
+            stream.custom_close()
+        except AttributeError:
+            pass
 
     # Post-tuning cleanup
     if batch_mode:
-        model.end()  # terminate the dummy model
+        # Terminate the dummy model
+        model.end()
     else:
         # Restore prior state
         model.log_output = prior_log_output

--- a/tests/unit_tests/model_funcs/model_funcs_test.py
+++ b/tests/unit_tests/model_funcs/model_funcs_test.py
@@ -98,13 +98,6 @@ def test_solve_solution_pass():
     assert sol1.to_string() == sol2.to_string()
 
 
-def test_solve_logoutput_true_pass(capsys, mdl, expected_log_start, expected_log_end):
-    _ = solve(mdl, log_output=True)
-    captured = capsys.readouterr().out
-
-    validate_logoutput(captured, expected_log_start % mdl.name, expected_log_end)
-
-
 def test_solve_logoutput_context_pass(capsys, mdl, expected_log_start, expected_log_end):
     mdl.context.solver.log_output = True
     _ = solve(mdl)
@@ -113,15 +106,17 @@ def test_solve_logoutput_context_pass(capsys, mdl, expected_log_start, expected_
     validate_logoutput(captured, expected_log_start % mdl.name, expected_log_end)
 
 
-def test_solve_logoutput_stdout_pass(capsys, mdl, expected_log_start, expected_log_end):
-    _ = solve(mdl, log_output='stdout')
+@pytest.mark.parametrize('log_output', [True, 'stdout', 'sys.stdout', '1'])
+def test_solve_logoutput_stdout_pass(capsys, mdl, log_output, expected_log_start, expected_log_end):
+    _ = solve(mdl, log_output=log_output)
     captured = capsys.readouterr().out
 
     validate_logoutput(captured, expected_log_start % mdl.name, expected_log_end)
 
 
-def test_solve_logoutput_stderr_pass(capsys, mdl, expected_log_start, expected_log_end):
-    _ = solve(mdl, log_output='stderr')
+@pytest.mark.parametrize('log_output', ['stderr', 'sys.stderr'])
+def test_solve_logoutput_stderr_pass(capsys, mdl, log_output, expected_log_start, expected_log_end):
+    _ = solve(mdl, log_output=log_output)
     captured = capsys.readouterr().err
 
     validate_logoutput(captured, expected_log_start % mdl.name, expected_log_end)
@@ -144,12 +139,9 @@ def test_solve_logoutput_fileobj_pass(tmp_path, mdl, expected_log_start, expecte
     validate_logoutput(captured, expected_log_start % mdl.name, expected_log_end)
 
 
-@pytest.mark.parametrize('config', ['log_output=False', 'no log_output'])
-def test_solve_logoutput_false_pass(capsys, mdl, config):
-    if config == 'log_output=False':
-        _ = solve(mdl, log_output=False)
-    if config == 'no log_output':
-        _ = solve(mdl)
+@pytest.mark.parametrize('log_output', [False, '0', None])
+def test_solve_logoutput_false_pass(capsys, mdl, log_output):
+    _ = solve(mdl, log_output=log_output)
 
     captured = capsys.readouterr()
     expected = ''


### PR DESCRIPTION
Solve:
* Handle edge case for `log_output='0'`.
* Like the tuning impl, combine successive stream.write calls for efficiency.
* Reorganize tests for different `log_output` cases.

Tuning:
* Close stream when log is output to a file created by DOcplex.