### PR TITLE
Add efficient subset check for sparse sets; miscellaneous fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.8.4
     hooks:
     -   id: ruff
         args: [ --fix,  --show-fixes ]

--- a/docs/source/api_reference/index_sets.rst
+++ b/docs/source/api_reference/index_sets.rst
@@ -23,6 +23,33 @@ Attributes
 
    IndexSet1D.name
 
+Set comparison
+--------------
+
+* If two sets have the same elements:
+
+   >>> set_a == set_b
+
+* If two sets have different elements:
+
+   >>> set_a != set_b
+
+* If one set is a subset of another:
+
+   >>> set_a <= set_b
+
+* If one set is a proper subset of another:
+
+   >>> set_a < set_b
+
+* If one set is a superset of another:
+
+   >>> set_a >= set_b
+
+* If one set is a proper superset of another:
+
+   >>> set_a > set_b
+
 Sequence operations
 -------------------
 .. autosummary::
@@ -48,12 +75,6 @@ Dunder methods
 - ``IndexSet1D.__delitem__``
 - ``IndexSet1D.__add__``
 - ``IndexSet1D.__iadd__``
-- ``IndexSet1D.__lt__``
-- ``IndexSet1D.__le__``
-- ``IndexSet1D.__eq__``
-- ``IndexSet1D.__ne__``
-- ``IndexSet1D.__gt__``
-- ``IndexSet1D.__ge__``
 
 ----------
 IndexSetND
@@ -81,6 +102,52 @@ Efficient subset selection
    IndexSetND.subset
    IndexSetND.squeeze
 
+Set comparison
+--------------
+
+* If two sets have the same elements:
+
+  >>> set_a == set_b
+
+* If two sets have different elements:
+
+   >>> set_a != set_b
+
+* If one set is a subset of another:
+
+   >>> set_a <= set_b
+
+   *A more efficient approach for sparse sets:*
+
+   If ``set_a`` is a 3-dim set (of type IndexSetND) and is composed of sparse
+   combinations of elements of three 1-dim sets ``set_x``, ``set_y``, and
+   ``set_z`` respectively (each of type IndexSet1D). Then an efficient subset
+   check for ``set_a`` can be directly made with a tuple of ``set_x``, ``set_y``,
+   and ``set_z`` – without having to enumerate all possible combinations from
+   the three.
+
+   >>> set_a <= (set_x, set_y, set_z)
+
+   Can raise the following errors:
+
+   * ``LookupError``: If the IndexSetND is empty and checked with a tuple of
+     IndexSet1D.
+
+   * ``ValueError``: If the IndexSetND is checked with a tuple of IndexSet1D that
+     is not the same length as the elements of the IndexSetND.
+
+* If one set is a proper subset of another:
+
+   >>> set_a < set_b
+
+* If one set is a superset of another:
+
+   >>> set_a >= set_b
+
+* If one set is a proper superset of another:
+
+   >>> set_a > set_b
+
 Sequence operations
 -------------------
 .. autosummary::
@@ -106,12 +173,6 @@ Dunder methods
 - ``IndexSetND.__delitem__``
 - ``IndexSetND.__add__``
 - ``IndexSetND.__iadd__``
-- ``IndexSetND.__lt__``
-- ``IndexSetND.__le__``
-- ``IndexSetND.__eq__``
-- ``IndexSetND.__ne__``
-- ``IndexSetND.__gt__``
-- ``IndexSetND.__ge__``
 
 ------------------------------------------
 Casting from pandas Series/DataFrame/Index

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,7 @@ html_short_title = html_title = 'docplex-extensions documentation'
 html_theme = 'ansys_sphinx_theme'
 html_static_path = ['_static']
 html_favicon = os.path.abspath('_static/favicon.png')
-html_sidebars = {'installation/*': [], 'user_guide/*': []}
+html_sidebars = {'installation/*': []}
 html_context = {
     'github_user': 'samarthmistry',
     'github_repo': 'docplex-extensions',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,7 +32,7 @@ Features
 Documentation
 -------------
 
-.. grid:: 3
+.. grid:: 4
 
    .. grid-item-card:: Installation
        :link: installation/index
@@ -58,6 +58,13 @@ Documentation
 
        :material-regular:`computer;2em`
 
+   .. grid-item-card:: Changelog
+       :link: https://github.com/samarthmistry/docplex-extensions/releases
+       :text-align: center
+       :margin: 2 auto auto auto
+
+       :material-regular:`track_changes;2em`
+
 .. toctree::
    :hidden:
    :maxdepth: 1
@@ -65,6 +72,7 @@ Documentation
    installation/index
    api_reference/index
    auto_examples/index
+   Changelog <https://github.com/samarthmistry/docplex-extensions/releases>
 
 -------
 License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ legacy_tox_ini = """
         tests
         cplex-runtime
     package = wheel
+    wheel_build_env = .pkg
     commands =
         pytest --basetemp="{env_tmp_dir}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ legacy_tox_ini = """
         3.13 = py313
 
     [testenv]
-    description = Run doctests, unit tests, functional tests, and typing tests
+    description = Run doctests, unit tests, and functional tests
     setenv = PY_IGNORE_IMPORTMISMATCH=1
     extras =
         tests
@@ -203,13 +203,13 @@ legacy_tox_ini = """
         pytest --basetemp="{env_tmp_dir}"
 
     [testenv:mypy]
-    description = Run doctests, unit tests, functional tests, and typing tests
+    description = Run static type checks and typing tests
     setenv = PY_IGNORE_IMPORTMISMATCH=1
     extras = tests
     package = wheel
     commands =
         mypy src
-        mypy ./tests/typing_tests/
+        mypy tests/typing_tests
 
     [testenv:py{312,313}]
     # Since CPLEX runtime is not supported beyond python 3.11, we skip all runtime-based tests

--- a/src/docplex_extensions/_model_funcs.py
+++ b/src/docplex_extensions/_model_funcs.py
@@ -170,15 +170,16 @@ def runseeds(
 ) -> None:
     """Evaluate variability of a mixed-integer DOcplex model by solving with different random seeds.
 
-    This function is a wrapper around CPLEX's `runseeds` procedure. Refer to the CPLEX user manual
-    for more details about this functionality.
+    This function is a wrapper around CPLEX's `runseeds` procedure that reports variability
+    statistics in the output log. Refer to the CPLEX user manual for more details about this
+    functionality.
 
     Parameters
     ----------
     model : docplex.mp.model.Model
         DOcplex model.
     count : int
-        The number of times to solve the model, be default `30` (same as CPLEX).
+        The number of times to solve the model, by default `30` (same as CPLEX).
     log_output : True or str or stream object, optional
         Log output switch, in one of the following forms:
 
@@ -193,20 +194,20 @@ def runseeds(
     Raises
     ------
     ValueError
-        If the problem type is not mixed-integer (MILP, MIQP, MIQCP).
+        If the DOcplex model is not mixed-integer (MILP, MIQP, MIQCP).
     ValueError
         If count is not a positive number.
     """
     if not isinstance(model, Model):
         raise TypeError('`model` should be docplex.mp.model.Model')
     if model.problem_type not in ('MILP', 'MIQP', 'MIQCP'):
-        raise ValueError('runseeds only supports mixed-integer problem types (MILP, MIQP, MIQCP)')
+        raise ValueError('runseeds only supports mixed-integer DOcplex models (MILP, MIQP, MIQCP)')
 
     if not isinstance(count, int) or count < 1:
-        raise ValueError('count should be a positive integer')
+        raise ValueError('`count` should be a positive integer')
 
     if log_output in (False, '0', None):
-        raise ValueError('`log_output` should be a True or str or stream object')
+        raise ValueError('`log_output` should be True or str or a stream object')
     elif log_output == '1':
         log_output = True
     if not (
@@ -214,7 +215,7 @@ def runseeds(
         or isinstance(log_output, str | TextIOBase)
         or (hasattr(log_output, 'write') and hasattr(log_output, 'flush'))
     ):
-        raise TypeError('`log_output` should be a True or str or stream object')
+        raise TypeError('`log_output` should be True or str or a stream object')
 
     # Register prior state so it can be restored at the end
     prior_log_output = model.log_output

--- a/src/docplex_extensions/_tuning_funcs.py
+++ b/src/docplex_extensions/_tuning_funcs.py
@@ -264,6 +264,8 @@ def _tune(
     else:
         # Restore prior state
         model.log_output = prior_log_output
+        for tuning_param_name in tuning_params:
+            attrgetter(tuning_param_name)(model.parameters).reset()
         for prior_name, prior_val in prior_params.items():
             attrgetter(prior_name)(model.parameters).set(prior_val)
         model.apply_parameters()

--- a/tests/unit_tests/index_sets/rich_comparison_test.py
+++ b/tests/unit_tests/index_sets/rich_comparison_test.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 
 import pytest
 
+from docplex_extensions import IndexSet1D
+
 
 @pytest.mark.parametrize(
     '_left, _right',
@@ -208,3 +210,61 @@ def test_set_sym_opr_invalid(request, _left, sym_opr, right):
     left = request.getfixturevalue(_left)
     with pytest.raises(TypeError):
         getattr(left, sym_opr)(right)
+
+
+@pytest.mark.parametrize(
+    '_left, right',
+    [
+        ('setNd_0', (IndexSet1D([0, 1]), IndexSet1D([0, 1]))),
+        ('setNd_01', (IndexSet1D([0, 1]), IndexSet1D([0, 1]))),
+        ('setNd_012', (IndexSet1D([0, 1]), IndexSet1D([0, 1, 2]))),
+        ('setNd_0', (IndexSet1D([0]), IndexSet1D([0, 1]))),
+        ('setNd_012', (IndexSet1D([0]), IndexSet1D([0, 1, 2]))),
+        ('setNd_int_cmb2', (IndexSet1D([0, 1]), IndexSet1D([0, 1]))),
+        ('setNd_int_cmb2', (IndexSet1D(range(9)), IndexSet1D(range(9)))),
+    ],
+)
+def test_set_is_le_sparse(request, _left, right):
+    left = request.getfixturevalue(_left)
+    assert left <= right
+
+
+@pytest.mark.parametrize(
+    '_left, right',
+    [
+        ('setNd_01', (IndexSet1D([0, 1]), IndexSet1D([0]))),
+        ('setNd_012', (IndexSet1D([0, 1]), IndexSet1D([0, 1]))),
+        ('setNd_int_cmb3', (IndexSet1D([0]), IndexSet1D([0]), IndexSet1D([0]))),
+        ('setNd_int_cmb3', (IndexSet1D([0]), IndexSet1D([0, 1]), IndexSet1D([0]))),
+    ],
+)
+def test_set_not_le_sparse(request, _left, right):
+    left = request.getfixturevalue(_left)
+    assert not left <= right
+
+
+@pytest.mark.parametrize(
+    '_left, right',
+    [
+        ('setNd_01', (IndexSet1D([0, 1]),)),
+        ('setNd_01', (IndexSet1D([0, 1]), IndexSet1D([0, 1]), IndexSet1D([0, 1]))),
+    ],
+)
+def test_set_is_le_sparse_len_valerr(request, _left, right):
+    left = request.getfixturevalue(_left)
+    with pytest.raises(ValueError):
+        _ = left <= right
+
+
+@pytest.mark.parametrize(
+    '_left, right',
+    [
+        ('setNd_emp', (IndexSet1D([0, 1]),)),
+        ('setNd_emp', (IndexSet1D([0, 1]), IndexSet1D([0, 1]))),
+        ('setNd_emp', (IndexSet1D([0, 1]), IndexSet1D([0, 1]), IndexSet1D([0, 1]))),
+    ],
+)
+def test_set_is_le_sparse_emp_lkperr(request, _left, right):
+    left = request.getfixturevalue(_left)
+    with pytest.raises(LookupError):
+        _ = left <= right

--- a/tests/unit_tests/model_funcs/tuning_funcs_test.py
+++ b/tests/unit_tests/model_funcs/tuning_funcs_test.py
@@ -373,7 +373,8 @@ def test_tune_persist_lo(tmp_path, mdl_to_tune, input, func):
     assert mdl_to_tune.log_output is prior_log_output
 
 
-def test_tune_persist_params(mdl_to_tune):
+@pytest.mark.parametrize('tune_kwargs', [{}, {'tuning_timelimit_sec': 10, 'repeat': 3}])
+def test_tune_persist_params(mdl_to_tune, tune_kwargs):
     mdl_to_tune.parameters.threads = 32
     mdl_to_tune.parameters.timelimit = 600
     mdl_to_tune.parameters.lpmethod = 4
@@ -382,7 +383,7 @@ def test_tune_persist_params(mdl_to_tune):
         for param in mdl_to_tune.parameters.generate_nondefault_params()
     }
 
-    _ = tune(mdl_to_tune)
+    _ = tune(mdl_to_tune, **tune_kwargs)
 
     post_params = {
         param.qualified_name: param.get()


### PR DESCRIPTION
Feature
* Add efficient subset check for sparse sets with rich comparison op `<=`.

Misc.
* Add changelog to doc homepage.
* Reset tuning params at the end of the tuning job.
* Update runseeds docs and error messages.